### PR TITLE
Display environment info in reports

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -206,6 +206,17 @@ td.warmup-plot {
   background-size: 1rem;
 }
 
+.btn-environment {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-left: auto;
+  content: "";
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' class='bi bi-motherboard' viewBox='0 0 16 16'%3E%3Cpath d='M11.5 2a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 .5-.5Zm2 0a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 .5-.5Zm-10 8a.5.5 0 0 0 0 1h6a.5.5 0 0 0 0-1h-6Zm0 2a.5.5 0 0 0 0 1h6a.5.5 0 0 0 0-1h-6ZM5 3a1 1 0 0 0-1 1h-.5a.5.5 0 0 0 0 1H4v1h-.5a.5.5 0 0 0 0 1H4a1 1 0 0 0 1 1v.5a.5.5 0 0 0 1 0V8h1v.5a.5.5 0 0 0 1 0V8a1 1 0 0 0 1-1h.5a.5.5 0 0 0 0-1H9V5h.5a.5.5 0 0 0 0-1H9a1 1 0 0 0-1-1v-.5a.5.5 0 0 0-1 0V3H6v-.5a.5.5 0 0 0-1 0V3Zm0 1h3v3H5V4Zm6.5 7a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h2a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5h-2Z'/%3E%3Cpath d='M1 2a2 2 0 0 1 2-2h11a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2v-2H.5a.5.5 0 0 1-.5-.5v-1A.5.5 0 0 1 .5 9H1V8H.5a.5.5 0 0 1-.5-.5v-1A.5.5 0 0 1 .5 6H1V5H.5a.5.5 0 0 1-.5-.5v-2A.5.5 0 0 1 .5 2H1Zm1 11a1 1 0 0 0 1 1h11a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v11Z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: 1rem;
+}
+
 .card-columns {
   column-count: 2;
 }

--- a/resources/style.css
+++ b/resources/style.css
@@ -212,7 +212,8 @@ td.warmup-plot {
   height: 1.25rem;
   margin-left: auto;
   content: "";
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' class='bi bi-motherboard' viewBox='0 0 16 16'%3E%3Cpath d='M11.5 2a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 .5-.5Zm2 0a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 .5-.5Zm-10 8a.5.5 0 0 0 0 1h6a.5.5 0 0 0 0-1h-6Zm0 2a.5.5 0 0 0 0 1h6a.5.5 0 0 0 0-1h-6ZM5 3a1 1 0 0 0-1 1h-.5a.5.5 0 0 0 0 1H4v1h-.5a.5.5 0 0 0 0 1H4a1 1 0 0 0 1 1v.5a.5.5 0 0 0 1 0V8h1v.5a.5.5 0 0 0 1 0V8a1 1 0 0 0 1-1h.5a.5.5 0 0 0 0-1H9V5h.5a.5.5 0 0 0 0-1H9a1 1 0 0 0-1-1v-.5a.5.5 0 0 0-1 0V3H6v-.5a.5.5 0 0 0-1 0V3Zm0 1h3v3H5V4Zm6.5 7a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h2a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5h-2Z'/%3E%3Cpath d='M1 2a2 2 0 0 1 2-2h11a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2v-2H.5a.5.5 0 0 1-.5-.5v-1A.5.5 0 0 1 .5 9H1V8H.5a.5.5 0 0 1-.5-.5v-1A.5.5 0 0 1 .5 6H1V5H.5a.5.5 0 0 1-.5-.5v-2A.5.5 0 0 1 .5 2H1Zm1 11a1 1 0 0 0 1 1h11a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v11Z'/%3E%3C/svg%3E");
+  /* src https://icons.getbootstrap.com/icons/cpu/ */
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' class='bi bi-motherboard' viewBox='0 0 16 16'%3E%3Cpath d='M5 0a.5.5 0 0 1 .5.5V2h1V.5a.5.5 0 0 1 1 0V2h1V.5a.5.5 0 0 1 1 0V2h1V.5a.5.5 0 0 1 1 0V2A2.5 2.5 0 0 1 14 4.5h1.5a.5.5 0 0 1 0 1H14v1h1.5a.5.5 0 0 1 0 1H14v1h1.5a.5.5 0 0 1 0 1H14v1h1.5a.5.5 0 0 1 0 1H14a2.5 2.5 0 0 1-2.5 2.5v1.5a.5.5 0 0 1-1 0V14h-1v1.5a.5.5 0 0 1-1 0V14h-1v1.5a.5.5 0 0 1-1 0V14h-1v1.5a.5.5 0 0 1-1 0V14A2.5 2.5 0 0 1 2 11.5H.5a.5.5 0 0 1 0-1H2v-1H.5a.5.5 0 0 1 0-1H2v-1H.5a.5.5 0 0 1 0-1H2v-1H.5a.5.5 0 0 1 0-1H2A2.5 2.5 0 0 1 4.5 2V.5A.5.5 0 0 1 5 0zm-.5 3A1.5 1.5 0 0 0 3 4.5v7A1.5 1.5 0 0 0 4.5 13h7a1.5 1.5 0 0 0 1.5-1.5v-7A1.5 1.5 0 0 0 11.5 3h-7zM5 6.5A1.5 1.5 0 0 1 6.5 5h3A1.5 1.5 0 0 1 11 6.5v3A1.5 1.5 0 0 1 9.5 11h-3A1.5 1.5 0 0 1 5 9.5v-3zM6.5 6a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5h-3z'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-size: 1rem;
 }
@@ -262,3 +263,4 @@ td.warmup-plot {
 .glyph-minus:before {
   content: "-";
 }
+

--- a/src/views/rebenchdb.R
+++ b/src/views/rebenchdb.R
@@ -101,6 +101,7 @@ profile_available_from <- "
     JOIN Executor ON execId = executor.id 
     "
 
+# fetch all benchmarks information from the database
 get_environments <- function(){
   qry <- dbSendQuery(rebenchdb, "SELECT id, hostname, ostype, memory, cpu, clockspeed FROM environment")
   result <- dbFetch(qry)

--- a/src/views/rebenchdb.R
+++ b/src/views/rebenchdb.R
@@ -46,7 +46,7 @@ main_data_select <- "
       cmdline, varValue, cores, inputSize, extraArgs,
       invocation, iteration, warmup,
       criterion.name as criterion, criterion.unit as unit,
-      value,  warmup, hostname, ostype, memory, cpu, clockspeed"
+      value,  warmup, envid"
 
 main_data_from <- "
     FROM Measurement
@@ -58,7 +58,7 @@ main_data_from <- "
       JOIN Suite ON suiteId = suite.id
       JOIN Benchmark ON benchmarkId = benchmark.id
       JOIN Executor ON execId = executor.id 
-      JOIN Environment ON Environment.id = envid "
+      "
 
 get_measures_for_comparison <- function(rebenchdb, hash_1, hash_2) {
   qry <- dbSendQuery(rebenchdb,
@@ -101,6 +101,20 @@ profile_available_from <- "
     JOIN Executor ON execId = executor.id 
     "
 
+get_environments <- function(){
+  qry <- dbSendQuery(rebenchdb, "SELECT id, hostname, ostype, memory, cpu, clockspeed FROM environment")
+  result <- dbFetch(qry)
+  dbClearResult(qry)
+  result$id <- factor(result$id)
+  result$hostname <- factor(result$hostname)
+  result$ostype <- factor(result$ostype)
+  result$memory <- factor(result$memory)
+  result$cpu <- factor(result$cpu)
+  result$clockspeed <- factor(result$clockspeed)
+
+  result
+}
+
 get_profile_availability <- function(rebenchdb, hash_1, hash_2) {
   qry <- dbSendQuery(rebenchdb,
                      paste0(profile_available_select, profile_available_from,
@@ -126,11 +140,11 @@ factorize_result <- function(result) {
   result$cores <- factor(result$cores)
   result$inputsize <- forcats::fct_explicit_na(factor(result$inputsize), na_level = "")
   result$extraargs <- forcats::fct_explicit_na(factor(result$extraargs), na_level = "")
-  #result$hostname <- result$hostname
-  #result$ostype <- factor(result$ostype)
-  #result$memory <- result$memory
-  #result$cpu <- factor(result$cpu)
-  #result$clockspeed <- result$clockspeed
+
+  if ("envid" %in% colnames(result)) {
+     result$envid <- factor(result$envid)
+  }
+  
   
   if ("criterion" %in% colnames(result)) {
     result$criterion <- factor(result$criterion)

--- a/src/views/rebenchdb.R
+++ b/src/views/rebenchdb.R
@@ -46,7 +46,7 @@ main_data_select <- "
       cmdline, varValue, cores, inputSize, extraArgs,
       invocation, iteration, warmup,
       criterion.name as criterion, criterion.unit as unit,
-      value "
+      value,  warmup, hostname, ostype, memory, cpu, clockspeed"
 
 main_data_from <- "
     FROM Measurement
@@ -57,7 +57,8 @@ main_data_from <- "
       JOIN Run ON runId = run.id
       JOIN Suite ON suiteId = suite.id
       JOIN Benchmark ON benchmarkId = benchmark.id
-      JOIN Executor ON execId = executor.id "
+      JOIN Executor ON execId = executor.id 
+      JOIN Environment ON Environment.id = envid "
 
 get_measures_for_comparison <- function(rebenchdb, hash_1, hash_2) {
   qry <- dbSendQuery(rebenchdb,
@@ -87,7 +88,7 @@ profile_available_select <- "
   SELECT expId, runId, trialId, substring(commitId, 1, 6) as commitid,
     benchmark.name as bench, executor.name as exe, suite.name as suite,
     cmdline, varValue, cores, inputSize, extraArgs,
-    invocation, numIterations, warmup "
+    invocation, numIterations"
 
 profile_available_from <- "
   FROM ProfileData
@@ -97,7 +98,8 @@ profile_available_from <- "
     JOIN Run ON runId = run.id
     JOIN Suite ON suiteId = suite.id
     JOIN Benchmark ON benchmarkId = benchmark.id
-    JOIN Executor ON execId = executor.id "
+    JOIN Executor ON execId = executor.id 
+    "
 
 get_profile_availability <- function(rebenchdb, hash_1, hash_2) {
   qry <- dbSendQuery(rebenchdb,
@@ -124,6 +126,11 @@ factorize_result <- function(result) {
   result$cores <- factor(result$cores)
   result$inputsize <- forcats::fct_explicit_na(factor(result$inputsize), na_level = "")
   result$extraargs <- forcats::fct_explicit_na(factor(result$extraargs), na_level = "")
+  #result$hostname <- result$hostname
+  #result$ostype <- factor(result$ostype)
+  #result$memory <- result$memory
+  #result$cpu <- factor(result$cpu)
+  #result$clockspeed <- result$clockspeed
   
   if ("criterion" %in% colnames(result)) {
     result$criterion <- factor(result$criterion)

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -102,7 +102,8 @@ if (cmds[1] == "from-file") {
   # load_and_install_if_necessary("psych")   # uses only geometric.mean
   rebenchdb <- connect_to_rebenchdb(db_name, db_user, db_pass)
   result <- get_measures_for_comparison(rebenchdb, baseline_hash, change_hash)
-  profiles <- get_profile_availability(rebenchdb, baseline_hash, change_hash)
+  profiles <- get_profile_availability(rebenchdb, baseline_hash, change_hash)  
+  environments <- get_environments()  
   disconnect_rebenchdb(rebenchdb)
 }
 
@@ -368,9 +369,12 @@ if (nrow(not_in_both) > 0) {
 
 out("<h2>Benchmark Performance</h2>")
 
-perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_row_count, group, colors, colors_light) {
+perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_row_count, group, colors, colors_light, environments) {
   group_col <- enquo(group)
   row_count <- start_row_count
+  
+
+  environmentsframe <- data.frame(environments)
 
   out('<table class="table table-sm benchmark-details">')
   out('<thead><tr>
@@ -387,17 +391,25 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
   # b <- "DeltaBlue"
   # data_ea <- data_b
 
-  for (b in levels(data_es$bench)) { data_b <- data_es %>% filter(bench == b) %>% droplevels()
+  for (b in levels(data_es$bench)) { data_b <- data_es %>% filter(bench == b) %>% droplevels() # nolint
     for (v in levels(data_b$varvalue)) {   data_v  <- data_b %>% filter(varvalue == v)   %>% droplevels()
     for (c in levels(data_v$cores)) {      data_c  <- data_v %>% filter(cores == c)      %>% droplevels()
     for (i in levels(data_c$inputsize)) {  data_i  <- data_c %>% filter(inputsize == i)  %>% droplevels()
-    for (ea in levels(data_i$extraargs)) { data_ea <- data_i %>% filter(extraargs == ea) %>% droplevels()
+    for (ea in levels(data_i$extraargs)) { data_ea <- data_i %>% filter(extraargs == ea) %>% droplevels()    
+    #print(summary(data_ea))
+    #gfg
+    for (en in levels(data_ea$envid)) { data_en <- data_ea %>% filter(envid == en) %>% droplevels()
+    #print("point 0")
+    #if (length(levels(data_ea$hostname))  > 1) { environment <- data_ea$hostname}
+    # environment <- results$hostname
+
 
     args <- ""
     if (length(levels(data_b$varvalue))  > 1) { args <- paste0(args, v) }
     if (length(levels(data_v$cores))     > 1) { args <- paste0(args, c) }
     if (length(levels(data_c$inputsize)) > 1) { args <- paste0(args, i) }
     if (length(levels(data_i$extraargs)) > 1) { args <- paste0(args, ea) }
+    #if (length(levels(data_ea$en)) > 1) { args <- paste0(args, en) }
     if (nchar(args) > 0) {
       args <- paste0('<span class="all-args">', args, '</span>')
     }
@@ -405,16 +417,20 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
     # capture the beginning of the path but leave the last element of it
     # this regex is also used in render.js's renderBenchmark() function
     cmdline <- str_replace_all(data_i$cmdline[[1]], "^([^\\s]*)((?:\\/\\w+)\\s.*$)", ".\\2")
-
+   # print("point 0.2")
     stats_b_total <- stats_es %>%
       ungroup() %>%
+      #, envid == en
       filter(bench == b, varvalue == v, cores == c, inputsize == i, extraargs == ea, criterion == "total") %>%
       droplevels()
+    #print("point 0.3")
     stats_b_gctime <- stats_es %>%
       ungroup() %>%
       filter(bench == b, varvalue == v, cores == c, inputsize == i, extraargs == ea, criterion == "GC time") %>%
       droplevels()
 
+    #print("point 1")
+    
     if ("commitid" %in% colnames(stats_b_total)) {
       stats_b_total <- stats_b_total %>%
         filter(commitid == change_hash6) %>%
@@ -426,7 +442,7 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
         droplevels()
     }
 
-    group_size <- (data_ea %>%
+    group_size <- (data_en %>%
                      filter(criterion == "total") %>%
                      select(!!group_col) %>%
                      unique() %>%
@@ -436,7 +452,7 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
       out('<tr>')
       out('<th scope="row">',  b, args, '</th>')
       out('<td>')
-      p <- small_inline_comparison(data_ea, !!group_col, colors, colors_light)
+      p <- small_inline_comparison(data_en, !!group_col, colors, colors_light)
       img_file <- paste0('inline-', row_count, '.svg')
       ggsave(img_file, p, "svg", output_dir, width = 3.5, height = 0.12 + 0.14 * group_size, units = "in")
       out('<img src="', output_url, '/', img_file, '">')
@@ -515,9 +531,15 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
         }
         out('</td>\n')
       }
-      
-      out('<td><button type="button" class="btn btn-sm btn-cmdline" data-content="<code>', cmdline, '</code>"></button>\n')
-      out('<td><button type="button" class="btn btn-environment" ></button>\n') 
+      #print("point 2")
+      #print(levels(data_en$envid))
+      #print(environmentsframe[levels(data_en$envid), 2])
+      #print(as.character(environmentsframe[levels(data_en$envid), 2]))
+
+      out('<td><button type="button" eclass="btn btn-sm btn-cmdline" data-content="<code>', cmdline, '</code>"></button>\n')
+      out('<td><button type="button" class="btn btn-environment" data-content="', as.character(environmentsframe[levels(data_en$envid), 2]) ,'"></button>\n') 
+      #print("point 3")
+      #out('<td><button type="button" class="btn btn-environment" data-content="', paste(result$ostype, result$hostname , result$ostype ,result$memory , result$cpu ,  result$clockspeed), '"> ></button>\n') 
       warmup_ea <- warmup_es %>%
         filter(bench == b, varvalue == v, cores == c, inputsize == i, extraargs == ea) %>%
         droplevels()
@@ -548,7 +570,7 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
       out('<th scope="row">', b, '</th><td colspan="4">missing in one of the data sets</td>\n')
       out('</tr>')
     }
-    } } } }
+    } } } } }
   }
 
   out('</table>')
@@ -587,7 +609,7 @@ perf_diff_table <- function(norm, stats, start_row_count) {
 
       row_count <- perf_diff_table_es(
         data_s, stats_es, warmup_es, profiles_es,
-        row_count, commitid, chg_colors, chg_colors_light)
+        row_count, commitid, chg_colors, chg_colors_light, environments)
     }
   }
   row_count
@@ -681,7 +703,7 @@ if (nrow(suites_for_comparison) > 0) {
     out('<img src="', output_url, '/overview.', s, '.svg">')
 
     row_count <- perf_diff_table_es(
-      norm_s, stats_s, warmup_s, NULL, row_count + 1, exe, exes_colors, exes_colors_light)
+      norm_s, stats_s, warmup_s, NULL, row_count + 1, exe, exes_colors, exes_colors_light, environments)
   }
 
 }

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -396,12 +396,9 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
     for (c in levels(data_v$cores)) {      data_c  <- data_v %>% filter(cores == c)      %>% droplevels()
     for (i in levels(data_c$inputsize)) {  data_i  <- data_c %>% filter(inputsize == i)  %>% droplevels()
     for (ea in levels(data_i$extraargs)) { data_ea <- data_i %>% filter(extraargs == ea) %>% droplevels()    
-    #print(summary(data_ea))
-    #gfg
+
     for (en in levels(data_ea$envid)) { data_en <- data_ea %>% filter(envid == en) %>% droplevels()
-    #print("point 0")
-    #if (length(levels(data_ea$hostname))  > 1) { environment <- data_ea$hostname}
-    # environment <- results$hostname
+
 
 
     args <- ""
@@ -409,7 +406,7 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
     if (length(levels(data_v$cores))     > 1) { args <- paste0(args, c) }
     if (length(levels(data_c$inputsize)) > 1) { args <- paste0(args, i) }
     if (length(levels(data_i$extraargs)) > 1) { args <- paste0(args, ea) }
-    #if (length(levels(data_ea$en)) > 1) { args <- paste0(args, en) }
+    
     if (nchar(args) > 0) {
       args <- paste0('<span class="all-args">', args, '</span>')
     }
@@ -417,20 +414,16 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
     # capture the beginning of the path but leave the last element of it
     # this regex is also used in render.js's renderBenchmark() function
     cmdline <- str_replace_all(data_i$cmdline[[1]], "^([^\\s]*)((?:\\/\\w+)\\s.*$)", ".\\2")
-   # print("point 0.2")
+    environmentStr <- paste0("Hostname: ", as.character(environmentsframe[levels(data_en$envid), 2])," |  OS Type: ", as.character(environmentsframe[levels(data_en$envid), 3])," |  Memory: ", as.character(environmentsframe[levels(data_en$envid), 4]), " |  CPU: ", as.character(environmentsframe[levels(data_en$envid), 5]), " |  Clockspeed: " ,as.character(environmentsframe[levels(data_en$envid), 6]))
     stats_b_total <- stats_es %>%
-      ungroup() %>%
-      #, envid == en
+      ungroup() %>%     
       filter(bench == b, varvalue == v, cores == c, inputsize == i, extraargs == ea, criterion == "total") %>%
       droplevels()
-    #print("point 0.3")
     stats_b_gctime <- stats_es %>%
       ungroup() %>%
       filter(bench == b, varvalue == v, cores == c, inputsize == i, extraargs == ea, criterion == "GC time") %>%
       droplevels()
 
-    #print("point 1")
-    
     if ("commitid" %in% colnames(stats_b_total)) {
       stats_b_total <- stats_b_total %>%
         filter(commitid == change_hash6) %>%
@@ -531,15 +524,17 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
         }
         out('</td>\n')
       }
-      #print("point 2")
-      #print(levels(data_en$envid))
-      #print(environmentsframe[levels(data_en$envid), 2])
-      #print(as.character(environmentsframe[levels(data_en$envid), 2]))
 
-      out('<td><button type="button" eclass="btn btn-sm btn-cmdline" data-content="<code>', cmdline, '</code>"></button>\n')
-      out('<td><button type="button" class="btn btn-environment" data-content="', as.character(environmentsframe[levels(data_en$envid), 2]) ,'"></button>\n') 
-      #print("point 3")
-      #out('<td><button type="button" class="btn btn-environment" data-content="', paste(result$ostype, result$hostname , result$ostype ,result$memory , result$cpu ,  result$clockspeed), '"> ></button>\n') 
+      out('<td><button type="button" class="btn btn-sm btn-cmdline" data-content="<code>', cmdline, '</code>"></button>\n')
+      out('<button type="button" class="btn btn-sm btn-environment" data-toggle="popover" data-placement="top"
+        data-content="',environmentStr,'" >
+        </button>')
+      out('<script>
+          $(document).ready(function(){
+          $(', paste0( "'", '[data-toggle="popover"]' , "'" ) ,').popover();   
+          });
+          </script>')
+      #out('<td><button type="button" class="btn btn-environment" data-content="', as.character(environmentsframe[levels(data_en$envid), 2]) ,'"></button>\n') 
       warmup_ea <- warmup_es %>%
         filter(bench == b, varvalue == v, cores == c, inputsize == i, extraargs == ea) %>%
         droplevels()

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -517,7 +517,7 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
       }
       
       out('<td><button type="button" class="btn btn-sm btn-cmdline" data-content="<code>', cmdline, '</code>"></button>\n')
-
+      out('<td><button type="button" class="btn btn-environment" ></button>\n') 
       warmup_ea <- warmup_es %>%
         filter(bench == b, varvalue == v, cores == c, inputsize == i, extraargs == ea) %>%
         droplevels()

--- a/src/views/somns.R
+++ b/src/views/somns.R
@@ -414,7 +414,10 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
     # capture the beginning of the path but leave the last element of it
     # this regex is also used in render.js's renderBenchmark() function
     cmdline <- str_replace_all(data_i$cmdline[[1]], "^([^\\s]*)((?:\\/\\w+)\\s.*$)", ".\\2")
+
+    # format all environment information into a single string
     environmentStr <- paste0("Hostname: ", as.character(environmentsframe[levels(data_en$envid), 2])," |  OS Type: ", as.character(environmentsframe[levels(data_en$envid), 3])," |  Memory: ", as.character(environmentsframe[levels(data_en$envid), 4]), " |  CPU: ", as.character(environmentsframe[levels(data_en$envid), 5]), " |  Clockspeed: " ,as.character(environmentsframe[levels(data_en$envid), 6]))
+    
     stats_b_total <- stats_es %>%
       ungroup() %>%     
       filter(bench == b, varvalue == v, cores == c, inputsize == i, extraargs == ea, criterion == "total") %>%
@@ -526,16 +529,15 @@ perf_diff_table_es <- function(data_es, stats_es, warmup_es, profiles_es, start_
       }
 
       out('<td><button type="button" class="btn btn-sm btn-cmdline" data-content="<code>', cmdline, '</code>"></button>\n')
-      out('<button type="button" class="btn btn-sm btn-environment" data-toggle="popover" data-placement="top"
-        data-content="',environmentStr,'" >
-        </button>')
+      out('<button type="button" class="btn btn-sm btn-environment" data-toggle="popover" data-placement="top" data-content="',environmentStr,'" ></button>')
+      
+      # script to implement the popover for the environment button
       out('<script>
           $(document).ready(function(){
           $(', paste0( "'", '[data-toggle="popover"]' , "'" ) ,').popover();   
           });
           </script>')
-      #out('<td><button type="button" class="btn btn-environment" data-content="', as.character(environmentsframe[levels(data_en$envid), 2]) ,'"></button>\n') 
-      warmup_ea <- warmup_es %>%
+       warmup_ea <- warmup_es %>%
         filter(bench == b, varvalue == v, cores == c, inputsize == i, extraargs == ea) %>%
         droplevels()
 


### PR DESCRIPTION
All benchmarks now have an addition information button (A CPU icon). It will display:
	Hostname - Name of the machine this specific benchmark was run on
	OS type – the operating system of the machine
	Memory – the amount of the memory the machine has
	CPU – the type of CPU the machine has
	Clockspeed – the Clock speed of the CPU

The List of Environments is queried once per comparison and stored in memory, which should result in a minimal effect on [ReBenchDB](https://github.com/HumphreyHCB/HBReBenchDB) performance.